### PR TITLE
Adjusting to compile in OS X.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ LDLIBS=-llua
 OBJ=luadata.o data.o layout.o binary.o luautil.o luacompat502.o
 
 data.so: $(OBJ)
-	$(CC) -shared -o data.so $(OBJ)
+	$(CC) -shared -o data.so $(OBJ) $(LDLIBS)
 
 test: test.c data.so
 

--- a/sys/endian.h
+++ b/sys/endian.h
@@ -26,9 +26,18 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
+#ifndef _ENDIAN_H_
+#define _ENDIAN_H_
+
+#ifdef __MACH__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #ifdef __GNUC__
 #define bswap64 __builtin_bswap64
 #endif
 
+#endif /* _ENDIAN_H_ */


### PR DESCRIPTION
Some little fixes to make it compile on OS X 10.9.

```
➜  luadata git:(darwin) make -f GNUMakefile clean && make -f GNUMakefile test
rm -f *.so *.o test || true
gcc -I. -fPIC   -c -o luadata.o luadata.c
gcc -I. -fPIC   -c -o data.o data.c
gcc -I. -fPIC   -c -o layout.o layout.c
gcc -I. -fPIC   -c -o binary.o binary.c
gcc -I. -fPIC   -c -o luautil.o luautil.c
gcc -I. -fPIC   -c -o luacompat502.o luacompat502.c
gcc -shared -o data.so luadata.o data.o layout.o binary.o luautil.o luacompat502.o -llua
gcc -I. -fPIC    test.c data.so  -llua -o test
➜  luadata git:(darwin) ./test 
test passed ;-)
```
