### PR TITLE
Change preprocessor checks to use luadata in other linux modules

### DIFF
--- a/luadata.c
+++ b/luadata.c
@@ -331,8 +331,8 @@ ldata_topointer(lua_State *L, int index, size_t *size)
 	return data_get_ptr(data);
 }
 
-#ifdef _KERNEL
-#if defined(__NetBSD__) && defined(_MODULE)
+#if defined(_KERNEL) && defined(_MODULE)
+#if defined(__NetBSD__) 
 #include <sys/lua.h>
 #include <sys/module.h>
 


### PR DESCRIPTION
It may be required to use luadata's object files as part of other
linux modules, not as a standalone module itself. This change in
preprocessor checks allows this use case.