### PR TITLE
fix warnings under gcc linux

### DIFF
--- a/data.c
+++ b/data.c
@@ -177,7 +177,7 @@ data_new(lua_State *L, void *ptr, size_t size, bool free)
 {
 	handle_t *handle = handle_new_single(L, ptr, size, free);
 	if (handle == NULL)
-		return luaL_error(L, "not enough memory");
+		luaL_error(L, "not enough memory");
 
 	data_t   *data   = new_data(L, handle, 0, size);
 	return data;

--- a/sys/endian.h
+++ b/sys/endian.h
@@ -40,9 +40,15 @@
 
 #ifdef __GNUC__
 #define bswap64		__builtin_bswap64
+#ifndef BYTE_ORDER
 #define BYTE_ORDER	__BYTE_ORDER__
+#endif
+#ifndef LITTLE_ENDIAN
 #define LITTLE_ENDIAN	__ORDER_LITTLE_ENDIAN__
+#endif
+#ifndef BIG_ENDIAN
 #define BIG_ENDIAN	__ORDER_BIG_ENDIAN__
+#endif
 #endif
 
 #endif /* _ENDIAN_H_ */


### PR DESCRIPTION
just got some small warnings under gcc linux

`BYTE_ORDER` & `{LITTLE,BIG}_ENDIAN` was already defined
